### PR TITLE
Feature/deprecated s3 and iam warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ gives information such as
 
 # Notes for deployment
 
+Additionally this project contains helper module called `user-data` inside it there are two templates
+
+	/user-data
+	├── user_data_template
+	│   ├── bastion_host_cloudinit_config.tpl
+	│   └── node_cloudinit_ami_linux.tpl
+
+* `bastion_host_cloudinit_config` is user-data which will be used during bastion startup and is created for debian ec2 images(root module uses it). This config can be obtained as `user_data_bastion` output variable.
+* `node_cloudinit_ami_linux` is user-data which can be used by ecs or kubernetes nodes, you can append this user data to your instances and then you will be able to ssh into this nodes from bastion. This user-data file does not create docker image, so you are logged into directly into ec2 instances(not inside docker container). It is created for `ami_linux` optimized machines.  This config can be obtained as `user_data` output variable. This config can be obtained as `user_data_ami_linux` output variable. For now users are updated every 15 minutes, and old ones are not removed. Remember that instances using this user-data should have following policies:
+  * iam:ListUsers
+  * iam:GetGroup
+  * iam:GetSSHPublicKey
+  * iam:ListSSHPublicKeys
+  * iam:GetUser
+  * iam:ListGroups
+
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This Terraform deploys an sshd bastion service on AWS:
 
 # Overview
 
-This plan provides socket-activated sshd-containers with one container instantiated per connection and destroyed on connection termination or else after 12 hours- to deter things like reverse tunnels etc. The host assumes an IAM role, inherited by the containers, allowing it to query IAM users and request their ssh public keys lodged with AWS. The actual call for public keys is made with a GO binary, downloaded from S3 to the host at deploy time and made available via shared volume in the docker image. In use the Docker container queries AWS for users with ssh keys at runtime, creates local linux user accounts for them and handles their login. When the connection is closed the container exits. This means that users log in _as themselves_ and manage their own ssh keys using the AWS web console or CLI. For any given session they will arrive in a vanilla Ubuntu container with passwordless sudo and can install whatever applications and frameworks might be required for that session. Because the IAM identity checking and user account population is done at container run time and the containers are called on demand, there is no delay between creating an account with a public ssh key on AWS and being able to access the bastion. If users have more than one ssh public key then their account will be set up so that any of them may be used- AWS allows up to 5 keys per user. 
+This plan provides socket-activated sshd-containers with one container instantiated per connection and destroyed on connection termination or else after 12 hours- to deter things like reverse tunnels etc. The host assumes an IAM role, inherited by the containers, allowing it to query IAM users and request their ssh public keys lodged with AWS. The actual call for public keys is made with a GO binary,which is built during deployment and made available via shared volume in the docker image. In use the Docker container queries AWS for users with ssh keys at runtime, creates local linux user accounts for them and handles their login. AWS group name to query for ssh keys should be passed in `bastion_allowed_iam_group` variable. When the connection is closed the container exits. This means that users log in _as themselves_ and manage their own ssh keys using the AWS web console or CLI. For any given session they will arrive in a vanilla Ubuntu container with passwordless sudo and can install whatever applications and frameworks might be required for that session. Because the IAM identity checking and user account population is done at container run time and the containers are called on demand, there is no delay between creating an account with a public ssh key on AWS and being able to access the bastion. If users have more than one ssh public key then their account will be set up so that any of them may be used- AWS allows up to 5 keys per user.
 
 This plan creates a dns entry for the host of the format
 
@@ -12,20 +12,20 @@ This plan creates a dns entry for the host of the format
 e.g.
 
 	dev-eu-west-1-bastion-service.yourdomain.com
-	
+
 this ensures a consistent and obvious naming format for each combination of AWS account and region.
 
 The container shell prompt is set similarly but with a systemd incremented counter, e.g. for 'aws_user'
 
-    aws_user@dev-eu-west-1_1-172:~$ 
+    aws_user@dev-eu-west-1_1-172:~$
 
 and a subsequent container would have
 
-    aws_user@dev-eu-west-1_2-172:~$ 
+    aws_user@dev-eu-west-1_2-172:~$
 
 etc. Sadly the -172 (digits will vary) part is an artefact of systemd unit templating that appears difficult to avoid.
 
-**The host is set to run the latest patch release at deployment of Debian Stretch**. Debian was chosen because the socket activation requires systemd but Ubuntu 16.04 does not automatically set up dhcp for additional elastic network interfaces. **The login username is 'admin'**. The host sshd is available on port 2222 and uses standard ec2 ssh keying. If you do not whitelist any access to this port directly from the outside world (plan default) then it may be convenient to access from a container, e.g. with 
+**The host is set to run the latest patch release at deployment of Debian Stretch**. Debian was chosen because the socket activation requires systemd but Ubuntu 16.04 does not automatically set up dhcp for additional elastic network interfaces. **The login username is 'admin'**. The host sshd is available on port 2222 and uses standard ec2 ssh keying. If you do not whitelist any access to this port directly from the outside world (plan default) then it may be convenient to access from a container, e.g. with
 
     sudo apt install -y curl; ssh -p2222 admin@`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`
 
@@ -61,7 +61,7 @@ This solution will use the following mapping for those special characters in iam
 
 So for example if we have an iam user called `test+=,@test` (which uses all of the disputed characters)
 
-this username would translate to `testplusequalcommaattest` and they would need to shell in, e.g. with 
+this username would translate to `testplusequalcommaattest` and they would need to shell in, e.g. with
 
 `ssh testplusequalcommaattest@dev-eu-west-1-bastion-service.yourdomain.com`
 
@@ -71,7 +71,7 @@ this username would translate to `testplusequalcommaattest` and they would need 
 * They must manage their own ssh keys using the AWS interface(s), e.g. in the web console under **IAM/Users/Security credentials** and 'Upload SSH public key'.
 * The ssh server key is set at container build time. This means that it will change whenever the bastion host is respawned
 
-The following is referenced in "message of the day" on the container: 
+The following is referenced in "message of the day" on the container:
 
 * They have an Ubuntu userland with passwordless sudo within the container, so they can install whatever they find useful for that session
 * Every connection is given a newly instanced container, nothing persists to subsequent connections. Even if they make a second connection to the service from the same machine at the same time it will be a seperate container.
@@ -80,7 +80,7 @@ The following is referenced in "message of the day" on the container:
 
 ## Logging
 
-The sshd-worker container is launched with `v /dev/log:/dev/log` This causes logging information to be recorded in the host systemd journal which is not directly accesible from the container. It is thus simple to see who logged in and when by interrogating the host, e.g.
+The sshd-worker container is launched with `v /dev/log:/dev/log` This causes logging information to be recorded in the host systemd journal which is not directly accessible from the container. It is thus simple to see who logged in and when by interrogating the host, e.g.
 
 	journalctl | grep 'Accepted publickey'
 
@@ -95,24 +95,6 @@ gives information such as
 
 # Notes for deployment
 
-* **Currently the s3 bucket creation and go binary upload is done manually** Bear in mind that S3 bucket names must be *DNS globally unique*, i.e. for *all* users *everywhere* so we cannot neccesarily rely on automatically creating a bucket given with a given name as it may altready be taken.
-
-* This plan contains a submodule to create the IAM 'bastion_service' role and attached policies. If you are deploying to a new AWS account then you need to include this module. If you have already deployed to an AWS account but simply want to set up another bastion service host, e.g. in a different region, then you should comment out the module call near the top of 'main.tf'. If you do not then  be aware that when deploying to multiple regions within a single AWS account this plan will report 'failures' similar to the below. These are harmless but because IAM policies and roles span regions, this terraform plan 'as-is' tries to provision all resources in each region and generates failures if trying to create 'new' resources that already exist, e.g. as below. Unfortunately as at March 2018 It is not possible to use 'count' on Terraform *modules* and booleans are not otherwise supported.
-
-> 3 error(s) occurred:
-
-> * aws_iam_role.bastion_service_role: 1 error(s) occurred:
-
-> * aws_iam_role.bastion_service_role: Error creating IAM Role bastion_service_role: EntityAlreadyExists: Role with name bastion_service_role already exists.
-> 	status code: 409, request id: *********-*****-****-****-********
-> * aws_iam_policy.bastion-service-files-s3-bucket-read-only: 1 error(s) occurred:
-
-> * aws_iam_policy.bastion-service-files-s3-bucket-read-only: Error creating IAM policy bastion-service-files-s3-bucket-read-only: EntityAlreadyExists: A policy called bastion-service-files-s3-bucket-read-only already exists. Duplicate names are not allowed.
-> 	status code: 409, request id: *********-*****-****-****-********
-> * aws_iam_policy.check_ssh_authorized_keys: 1 error(s) occurred:
-
-> * aws_iam_policy.check_ssh_authorized_keys: Error creating IAM policy check_ssh_authorized_keys: EntityAlreadyExists: A policy called check_ssh_authorized_keys already exists. Duplicate names are not allowed.
-> 	status code: 409, request id: *********-*****-****-****-********
 
 ## Components
 
@@ -122,6 +104,7 @@ gives information such as
 * Systemd docker unit
 * Systemd service template unit
 * IAM Profile connected to EC2 host
+* golang
 
 **IAM Role module**
 
@@ -131,7 +114,7 @@ gives information such as
 
 **Docker container** 'sshd_worker' - built at host launch time using generic ubuntu image, we add sshd and sudo.
 
-**[Go binary](https://github.com/Fullscreen/iam-authorized-keys-command)**  manually made available in S3 for download to host- **be sure to make access read only to prevent people trojanning it!** For peace of mind the [upstream repo has been forked to a companion repo](https://github.com/joshuamkite/iam-authorized-keys-command).
+**[Go binary](https://github.com/Fullscreen/iam-authorized-keys-command)** code stored in this repo in `user-data\ima_authorized_keys_code\main.go` - **be sure to make access read only to prevent people trojanning it!** For peace of mind the [upstream repo has been forked to a companion repo](https://github.com/joshuamkite/iam-authorized-keys-command).
 
 The files in question on the host deploy thus:
 
@@ -143,9 +126,9 @@ The files in question on the host deploy thus:
 	    └── Dockerfile
 
 * `iam-helper` is made available as a read-only volume to the docker container as /opt.
-* `iam-authorized-keys-command` is the Go binary that gets the users and ssh public keys from aws
+* `iam-authorized-keys-command` is the Go binary that gets the users and ssh public keys from aws it is built during bastion deployment
 * `ssh_populate.sh` is the container entry point and populates the local user accounts using the go binary
-* `sshd_worker/Dockerfile` is obviously the docker build configuration. It uses a static release of Ubuntu (16.04 in dev) from the public Docker registry. 
+* `sshd_worker/Dockerfile` is obviously the docker build configuration. It uses a static release of Ubuntu (16.04 in dev) from the public Docker registry.
 
 ## Input Variables
 
@@ -155,23 +138,26 @@ A template.tfvars file is included for convenience
 
 ### Inputs
 
+## Inputs
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bastion_allowed_iam_group | Name IAM group, members of this group will be able to ssh into bastion instances if they have provided ssh key in their profile | string | - | yes |
 | bastion_instance_type | The virtual hardware to be used for the bastion service host | string | `t2.micro` | no |
 | bastion_service_host_key_name | AWS ssh key *.pem to be used for ssh access to the bastion service host | string | - | yes |
 | cidr_blocks_whitelist_host | range(s) of incoming IP addresses to whitelist for the HOST | list | `<list>` | no |
 | cidr_blocks_whitelist_service | range(s) of incoming IP addresses to whitelist for the SERVICE | list | - | yes |
 | dns_domain | The domain used for Route53 records | string | - | yes |
 | environment_name | the name of the environment that we are deploying to | string | `staging` | no |
-| iam_authorized_keys_command_url | location for our compiled Go binary - see https://github.com/Fullscreen/iam-authorized-keys-command | string | - | yes |
 | route53_zone_id | Route53 zoneId | string | - | yes |
-| s3_bucket_name | the name of the s3 bucket where we are storing our go binary | string | - | yes |
 | subnet_additional | list of names for any additional subnets | list | `<list>` | no |
 | subnet_master | The name for the main (or only!) subnet | string | - | yes |
+| tags | AWS tags that should be associated with created resources | map | `<map>` | no |
 | vpc | ID for Virtual Private Cloud to apply security policy and deploy stack to | string | - | yes |
 
-### Outputs
+## Outputs
 
 | Name | Description |
 |------|-------------|
 | service_dns_entry | dns-registered url for service and host |
+| user_data | cloud-config user data used to initialize bastion at start up |

--- a/iam_service_role/main.tf
+++ b/iam_service_role/main.tf
@@ -2,7 +2,7 @@
 #aws iam role for host
 ##############
 resource "aws_iam_role" "bastion_service_role" {
-  name = "bastion_service_role"
+  name = "${var.bastion_name}_bastion_service_role"
 
   assume_role_policy = <<EOF
 {
@@ -25,16 +25,12 @@ EOF
 #########################
 
 resource "aws_iam_instance_profile" "bastion_service_profile" {
-  name = "bastion_service_profile"
+  name = "${var.bastion_name}_bastion_service_profile"
   role = "${aws_iam_role.bastion_service_role.name}"
 }
 
-#########################
-#s3 bucket access policy for host
-#########################
-
 resource "aws_iam_policy" "check_ssh_authorized_keys" {
-  name        = "check_ssh_authorized_keys"
+  name        = "${var.bastion_name}_check_ssh_authorized_keys"
   description = "Allow querying aws to obtain list of users with their ssh public keys"
 
   policy = <<EOF
@@ -49,7 +45,7 @@ resource "aws_iam_policy" "check_ssh_authorized_keys" {
                 "iam:GetSSHPublicKey",
                 "iam:ListSSHPublicKeys",
                 "iam:GetUser",
-                "iam:ListGroups"               
+                "iam:ListGroups"
             ],
             "Resource": "*"
         },
@@ -66,33 +62,4 @@ EOF
 resource "aws_iam_role_policy_attachment" "check_ssh_authorized_keys" {
   role       = "${aws_iam_role.bastion_service_role.name}"
   policy_arn = "${aws_iam_policy.check_ssh_authorized_keys.arn}"
-}
-
-#########################
-#s3 bucket access policy for host
-#########################
-resource "aws_iam_policy" "bastion-service-files-s3-bucket-read-only" {
-  name        = "bastion-service-files-s3-bucket-read-only"
-  description = "Allow read only access for bastion service host role to golang binary used for querying aws for users and public ssh ssh keys by role check_ssh_authorized_keys"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "s3:GetObject",
-            "Resource": [
-                "arn:aws:s3:::${var.s3_bucket_name}",
-                "arn:aws:s3:::${var.s3_bucket_name}/*"
-            ]
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "bastion-service-files-s3-bucket-read-only" {
-  role       = "${aws_iam_role.bastion_service_role.name}"
-  policy_arn = "${aws_iam_policy.bastion-service-files-s3-bucket-read-only.arn}"
 }

--- a/iam_service_role/output.tf
+++ b/iam_service_role/output.tf
@@ -1,0 +1,3 @@
+output "instance_profile" {
+  value = "${aws_iam_instance_profile.bastion_service_profile.name}"
+}

--- a/iam_service_role/variables.tf
+++ b/iam_service_role/variables.tf
@@ -1,3 +1,3 @@
-variable "s3_bucket_name" {
-  description = "the name of the s3 bucket where we are storing our go binary"
+variable "bastion_name" {
+  description = "the name that will prefix bastion roles/policies"
 }

--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,7 @@ resource "aws_instance" "bastion_service_host" {
   subnet_id                   = "${var.subnet_master}"
   associate_public_ip_address = "true"
   vpc_security_group_ids      = ["${aws_security_group.instance.id}"]
-  user_data                   = "${module.bastion_user_data.user_data}"
+  user_data                   = "${module.bastion_user_data.user_data_bastion}"
   key_name                    = "${var.bastion_service_host_key_name}"
   iam_instance_profile        = "${module.iam_service_role.instance_profile}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,9 @@
 output "user_data_bastion" {
   description = "cloud-config user data used to initialize bastion at start up"
-  value       = "${module.bastion_user_data.user_data}"
+  value       = "${module.bastion_user_data.user_data_bastion}"
+}
+
+output "user_data_ami_linux" {
+  description = "cloud-config user data used to initialize ami linux instances which are run as ecs/k8s nodes"
+  value       = "${module.bastion_user_data.user_data_ami_linux}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "user_data" {
+  description = "cloud-config user data used to initialize bastion at start up"
+  value       = "${module.bastion_user_data.user_data}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "user_data" {
+output "user_data_bastion" {
   description = "cloud-config user data used to initialize bastion at start up"
   value       = "${module.bastion_user_data.user_data}"
 }

--- a/template.tfvars
+++ b/template.tfvars
@@ -1,9 +1,15 @@
 vpc = ""
+
 subnet_master = ""
+
 bastion_service_host_key_name = ""
-iam_authorized_keys_command_url = ""
-s3_bucket_name = ""
+
 cidr_blocks_whitelist_service = [""]
+
 dns_domain = ""
+
 route53_zone_id = ""
+
 environment_name = ""
+
+tags = {}

--- a/user-data/iam_authorized_keys_code/main.go
+++ b/user-data/iam_authorized_keys_code/main.go
@@ -71,10 +71,15 @@ func main() {
 						SSHPublicKeyId: k.SSHPublicKeyId,
 						UserName:       userName,
 					}
-					resp, _ := svc.GetSSHPublicKey(params)
+					resp, err := svc.GetSSHPublicKey(params)
+					if err != nil {
+						fmt.Fprintln(os.Stderr, err.Error())
+					}
 					fmt.Printf("# %s\n", *userName)
 					fmt.Println(*resp.SSHPublicKey.SSHPublicKeyBody)
 				}
+			} else {
+				fmt.Fprintln(os.Stderr, err.Error())
 			}
 			wg.Done()
 		}(u.UserName)

--- a/user-data/iam_authorized_keys_code/main.go
+++ b/user-data/iam_authorized_keys_code/main.go
@@ -1,0 +1,99 @@
+// This code is taken from https://github.com/Fullscreen/iam-authorized-keys-command
+// Its responsibility is to query iam service for users that match criteria, and add them to ec2 instance on which this is run
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+const (
+	exitCodeOk    int = 0
+	exitCodeError int = 1
+)
+
+var (
+	wg sync.WaitGroup
+
+	iamGroup    = ""
+	sshUserName = ""
+)
+
+func main() {
+	sess, _ := session.NewSession()
+	svc := iam.New(sess)
+
+	// check for valid user name
+	if sshUserName != "" && (len(os.Args) < 2 || os.Args[1] != sshUserName) {
+		os.Exit(exitCodeOk)
+	}
+
+	// Handle SIGPIPE
+	//
+	// When sshd identifies a key in the stdout of this command, it closes
+	// the pipe causing a series of EPIPE errors before a SIGPIPE is emitted
+	// on this scripts pid. If the script exits with the standard 13 code, sshd
+	// will disregard any matched keys. We catch the signal here and exit 0 to
+	// fix that problem.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGPIPE)
+	go func() {
+		_ = <-c
+		os.Exit(exitCodeOk)
+	}()
+
+	users, err := users(svc, iamGroup)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(exitCodeError)
+	}
+
+	for _, u := range users {
+		wg.Add(1)
+		go func(userName *string) {
+			params := &iam.ListSSHPublicKeysInput{
+				UserName: userName,
+			}
+			if resp, err := svc.ListSSHPublicKeys(params); err == nil {
+				for _, k := range resp.SSHPublicKeys {
+					if *k.Status != "Active" {
+						continue
+					}
+					params := &iam.GetSSHPublicKeyInput{
+						Encoding:       aws.String("SSH"),
+						SSHPublicKeyId: k.SSHPublicKeyId,
+						UserName:       userName,
+					}
+					resp, _ := svc.GetSSHPublicKey(params)
+					fmt.Printf("# %s\n", *userName)
+					fmt.Println(*resp.SSHPublicKey.SSHPublicKeyBody)
+				}
+			}
+			wg.Done()
+		}(u.UserName)
+	}
+	wg.Wait()
+}
+
+// get all IAM users, or just those that are part of the defined group
+func users(svc *iam.IAM, iamGroup string) ([]*iam.User, error) {
+	if iamGroup != "" {
+		params := &iam.GetGroupInput{
+			GroupName: aws.String(iamGroup),
+		}
+		resp, err := svc.GetGroup(params)
+		return resp.Users, err
+	}
+	params := &iam.ListUsersInput{
+		MaxItems: aws.Int64(100),
+	}
+	resp, err := svc.ListUsers(params)
+	return resp.Users, err
+}

--- a/user-data/main.tf
+++ b/user-data/main.tf
@@ -15,3 +15,13 @@ data "template_file" "bastion_host" {
     bastion_allowed_iam_group = "${var.bastion_allowed_iam_group}"
   }
 }
+
+data "template_file" "user_data_ami_linux" {
+  template = "${file("${path.module}/user_data_template/node_cloudinit_ami_linux.tpl")}"
+
+  vars {
+    bastion_host_name         = "${var.environment_name}-${data.aws_region.current.name}"
+    authorized_command_code   = "${indent(8, file("${path.module}/iam_authorized_keys_code/main.go"))}"
+    bastion_allowed_iam_group = "${var.bastion_allowed_iam_group}"
+  }
+}

--- a/user-data/main.tf
+++ b/user-data/main.tf
@@ -1,0 +1,17 @@
+#get aws region for use later in plan
+data "aws_region" "current" {}
+
+#######################
+# Copy templates files to bastion host
+####################
+
+# userdata for bastion host
+data "template_file" "bastion_host" {
+  template = "${file("${path.module}/user_data_template/bastion_host_cloudinit_config.tpl")}"
+
+  vars {
+    bastion_host_name         = "${var.environment_name}-${data.aws_region.current.name}"
+    authorized_command_code   = "${indent(8, file("${path.module}/iam_authorized_keys_code/main.go"))}"
+    bastion_allowed_iam_group = "${var.bastion_allowed_iam_group}"
+  }
+}

--- a/user-data/outputs.tf
+++ b/user-data/outputs.tf
@@ -1,4 +1,4 @@
-output "user_data" {
+output "user_data_bastion" {
   description = "cloud-config user data used to initialize bastion at start up"
   value       = "${data.template_file.bastion_host.rendered}"
 }

--- a/user-data/outputs.tf
+++ b/user-data/outputs.tf
@@ -1,0 +1,4 @@
+output "user_data" {
+  description = "cloud-config user data used to initialize bastion at start up"
+  value       = "${data.template_file.bastion_host.rendered}"
+}

--- a/user-data/outputs.tf
+++ b/user-data/outputs.tf
@@ -2,3 +2,8 @@ output "user_data" {
   description = "cloud-config user data used to initialize bastion at start up"
   value       = "${data.template_file.bastion_host.rendered}"
 }
+
+output "user_data_ami_linux" {
+  description = "cloud-config user data used to initialize ami linux instances which are run as ecs/k8s nodes"
+  value       = "${data.template_file.user_data_ami_linux.rendered}"
+}

--- a/user-data/user_data_template/node_cloudinit_ami_linux.tpl
+++ b/user-data/user_data_template/node_cloudinit_ami_linux.tpl
@@ -1,0 +1,68 @@
+#cloud-config
+---
+package_update: true
+packages:
+  - python-pip
+
+write_files:
+  -
+    content: |
+      */15 * * * * root /opt/iam_helper/ssh_populate.sh
+    path: /etc/cron.d/ssh_populate
+
+  -
+    content: |
+        #!/bin/bash
+        (
+        count=1
+        /opt/iam_helper/iam-authorized-keys-command | while read line
+        do
+          username=$( echo $line | sed -e 's/^# //' -e 's/+/plus/' -e 's/=/equal/' -e 's/,/comma/' -e 's/@/at/' )
+          useradd -m -s /bin/bash -k /etc/skel $username
+          usermod -a -G sudo $username
+          echo $username\ 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/$count
+          chmod 0440 /etc/sudoers.d/$count
+          count=$(( $count + 1 ))
+          mkdir /home/$username/.ssh
+          read line2
+          echo $line2 >> /home/$username/.ssh/authorized_keys
+          chown -R $username:$username /home/$username/.ssh
+          chmod 700 /home/$username/.ssh
+          chmod 0600 /home/$username/.ssh/authorized_keys
+        done
+
+        ) > /dev/null 2>&1
+
+    path: /opt/iam_helper/ssh_populate.sh
+    permissions: '0754'
+
+  -
+    content: |
+        ${authorized_command_code}
+    path: /opt/golang/src/iam-authorized-keys-command/main.go
+    permissions: '0754'
+
+  -
+    content: |
+        #!/bin/bash
+        mkdir /opt/iam_helper
+
+        # build iam-authorized-keys-command
+        sudo yum install -y golang
+        export GOPATH=/opt/golang
+
+        COMMAND_DIR=$GOPATH/src/iam-authorized-keys-command
+
+        mkdir -p $COMMAND_DIR
+        cd $COMMAND_DIR
+
+        go get ./...
+        go build -ldflags "-X main.iamGroup=${bastion_allowed_iam_group}" -o /opt/iam_helper/iam-authorized-keys-command ./main.go
+
+        chown root /opt/iam_helper
+        chmod -R 700 /opt/iam_helper
+
+    path: /var/lib/cloud/scripts/per-once/localinstall.sh
+    permissions: '0754'
+
+

--- a/user-data/user_data_template/node_cloudinit_ami_linux.tpl
+++ b/user-data/user_data_template/node_cloudinit_ami_linux.tpl
@@ -7,13 +7,7 @@ packages:
 write_files:
   -
     content: |
-      */15 * * * * root /opt/iam_helper/ssh_populate.sh
-    path: /etc/cron.d/ssh_populate
-
-  -
-    content: |
         #!/bin/bash
-        (
         count=1
         /opt/iam_helper/iam-authorized-keys-command | while read line
         do
@@ -30,9 +24,6 @@ write_files:
           chmod 700 /home/$username/.ssh
           chmod 0600 /home/$username/.ssh/authorized_keys
         done
-
-        ) > /dev/null 2>&1
-
     path: /opt/iam_helper/ssh_populate.sh
     permissions: '0754'
 
@@ -62,6 +53,8 @@ write_files:
         chown root /opt/iam_helper
         chmod -R 700 /opt/iam_helper
 
+        /opt/iam_helper/ssh_populate.sh
+        crontab -l | { cat; echo "*/15 * * * * /opt/iam_helper/ssh_populate.sh > /var/log/ssh_populate.log"; } | crontab -
     path: /var/lib/cloud/scripts/per-once/localinstall.sh
     permissions: '0754'
 

--- a/user-data/variables.tf
+++ b/user-data/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  description = "the name of the environment that we are deploying to"
+  default     = "staging"
+}
+
+variable "bastion_allowed_iam_group" {
+  type        = "string"
+  description = "Name IAM group, members of this group will be able to ssh into bastion instances if they have provided ssh key in their profile"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -50,10 +50,13 @@ variable "route53_zone_id" {
   description = "Route53 zoneId"
 }
 
-variable "iam_authorized_keys_command_url" {
-  description = "location for our compiled Go binary - see https://github.com/Fullscreen/iam-authorized-keys-command"
+variable "bastion_allowed_iam_group" {
+  type        = "string"
+  description = "Name IAM group, members of this group will be able to ssh into bastion instances if they have provided ssh key in their profile"
 }
 
-variable "s3_bucket_name" {
-  description = "the name of the s3 bucket where we are storing our go binary"
+variable "tags" {
+  type        = "map"
+  description = "AWS tags that should be associated with created resources"
+  default     = {}
 }


### PR DESCRIPTION
Few changes:
- S3 bucket is no longer necessary, golang script for iam-authorized-command is stored inside this repository.
- IAM roles are generated based on region and environment role, so there should be no more conflicts.
- Added additional user-data file to output variables, it can be used to populate ecs/k8s nodes(based on amazon linux image), to allow sshing from bastion into nodes.   
- added tags variable ( it will attach additional tags to aws resources) 