### PR TITLE
Join bastion_service names to prevent error when route53_zone_id is not defined.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "service_dns_entry" {
   description = "dns-registered url for service and host"
-  value       = "${join(",", aws_route53_record.bastion_service.*.name)}"
+  value       = "${join("", aws_route53_record.bastion_service.*.name)}"
 }
 
 output "policy_example_for_parent_account_empty_if_not_used" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "service_dns_entry" {
   description = "dns-registered url for service and host"
-  value       = "${aws_route53_record.bastion_service.*.name[0]}"
+  value       = "${join(",", aws_route53_record.bastion_service.*.name)}"
 }
 
 output "policy_example_for_parent_account_empty_if_not_used" {


### PR DESCRIPTION
When route53_zone_id is not defined, things fail with the following error:

```
Error: Error refreshing state: 1 error(s) occurred:

* output.service_dns_entry: At column 44, line 1: list "aws_route53_record.bastion_service.*.name" does not have any elements so cannot determine type. in:

${aws_route53_record.bastion_service.*.name[0]}
```

The output for "policy_example_for_parent_account_empty_if_not_used" uses a join to work around a similar issue (I believe), so I applied the same strategy to the "service_dns_entry" output.