### PR TITLE
Change quote style for ssh_populate scripts to avoid early interpolation

### DIFF
--- a/user_data/ssh_populate_assume_role.tpl
+++ b/user_data/ssh_populate_assume_role.tpl
@@ -2,8 +2,8 @@
 mkdir -p /opt/iam_helper/
 cat << 'EOF' > /opt/iam_helper/ssh_populate.sh
 #!/bin/bash
-KST=(\`aws sts assume-role --role-arn "${assume_role_arn}" --role-session-name $(hostname) --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text\`)
-export AWS_ACCESS_KEY_ID=${KST[0]}; export AWS_SECRET_ACCESS_KEY=${KST[1]}; export AWS_SESSION_TOKEN=${KST[2]}
+KST=(`aws sts assume-role --role-arn "${assume_role_arn}" --role-session-name $(hostname) --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text`)
+export AWS_ACCESS_KEY_ID=$${KST[0]}; export AWS_SECRET_ACCESS_KEY=$${KST[1]}; export AWS_SESSION_TOKEN=$${KST[2]}
 (
 count=1
 /opt/iam-authorized-keys-command | while read line

--- a/user_data/ssh_populate_assume_role.tpl
+++ b/user_data/ssh_populate_assume_role.tpl
@@ -1,25 +1,25 @@
 #!/bin/bash
 mkdir -p /opt/iam_helper/
-cat << EOF > /opt/iam_helper/ssh_populate.sh
+cat << 'EOF' > /opt/iam_helper/ssh_populate.sh
 #!/bin/bash
-KST=(\`aws sts assume-role --role-arn "${assume_role_arn}" --role-session-name \$$(hostname) --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text\`)
-export AWS_ACCESS_KEY_ID=\$${KST[0]}; export AWS_SECRET_ACCESS_KEY=\$${KST[1]}; export AWS_SESSION_TOKEN=\$${KST[2]}
+KST=(\`aws sts assume-role --role-arn "${assume_role_arn}" --role-session-name $(hostname) --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text\`)
+export AWS_ACCESS_KEY_ID=${KST[0]}; export AWS_SECRET_ACCESS_KEY=${KST[1]}; export AWS_SESSION_TOKEN=${KST[2]}
 (
 count=1
 /opt/iam-authorized-keys-command | while read line
 do
-    username=\$$( echo \$$line | sed -e 's/^# //' -e 's/+/plus/' -e 's/=/equal/' -e 's/,/comma/' -e 's/@/at/' )
-    useradd -m -s /bin/bash -k /etc/skel \$$username
-    usermod -a -G sudo \$$username
-    echo \$$username\ 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/\$$count
-    chmod 0440 /etc/sudoers.d/\$$count
-    count=\$$(( \$$count + 1 ))
-    mkdir /home/\$$username/.ssh
+    username=$( echo $line | sed -e 's/^# //' -e 's/+/plus/' -e 's/=/equal/' -e 's/,/comma/' -e 's/@/at/' )
+    useradd -m -s /bin/bash -k /etc/skel $username
+    usermod -a -G sudo $username
+    echo $username\ 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/$count
+    chmod 0440 /etc/sudoers.d/$count
+    count=$(( $count + 1 ))
+    mkdir /home/$username/.ssh
     read line2
-    echo \$$line2 >> /home/\$$username/.ssh/authorized_keys
-    chown -R \$$username:\$$username /home/\$$username/.ssh
-    chmod 700 /home/\$$username/.ssh
-    chmod 0600 /home/\$$username/.ssh/authorized_keys
+    echo $line2 >> /home/$username/.ssh/authorized_keys
+    chown -R $username:$username /home/$username/.ssh
+    chmod 700 /home/$username/.ssh
+    chmod 0600 /home/$username/.ssh/authorized_keys
 done
 
 ) > /dev/null 2>&1

--- a/user_data/ssh_populate_same_account.tpl
+++ b/user_data/ssh_populate_same_account.tpl
@@ -1,23 +1,23 @@
 #!/bin/bash
 mkdir -p /opt/iam_helper/
-cat << EOF > /opt/iam_helper/ssh_populate.sh
+cat << 'EOF' > /opt/iam_helper/ssh_populate.sh
 #!/bin/bash
 (
 count=1
 /opt/iam-authorized-keys-command | while read line
 do
-    username=\$$( echo \$$line | sed -e 's/^# //' -e 's/+/plus/' -e 's/=/equal/' -e 's/,/comma/' -e 's/@/at/' )
-    useradd -m -s /bin/bash -k /etc/skel \$$username
-    usermod -a -G sudo \$$username
-    echo \$$username\ 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/\$$count
-    chmod 0440 /etc/sudoers.d/\$$count
-    count=\$$(( \$$count + 1 ))
-    mkdir /home/\$$username/.ssh
+    username=$( echo $line | sed -e 's/^# //' -e 's/+/plus/' -e 's/=/equal/' -e 's/,/comma/' -e 's/@/at/' )
+    useradd -m -s /bin/bash -k /etc/skel $username
+    usermod -a -G sudo $username
+    echo $username\ 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/$count
+    chmod 0440 /etc/sudoers.d/$count
+    count=$(( $count + 1 ))
+    mkdir /home/$username/.ssh
     read line2
-    echo \$$line2 >> /home/\$$username/.ssh/authorized_keys
-    chown -R \$$username:\$$username /home/\$$username/.ssh
-    chmod 700 /home/\$$username/.ssh
-    chmod 0600 /home/\$$username/.ssh/authorized_keys
+    echo $line2 >> /home/$username/.ssh/authorized_keys
+    chown -R $username:$username /home/$username/.ssh
+    chmod 700 /home/$username/.ssh
+    chmod 0600 /home/$username/.ssh/authorized_keys
 done
 
 ) > /dev/null 2>&1


### PR DESCRIPTION
We were having an issue with the here-doc in module_ssh_populate_same_account being evaluated instead of being written to /opt/iam_helper/ssh_populate.sh. This change causes the interpolation to be skipped when evaluating module_ssh_populate_same_account.

Doc reference here:

> The format of here-documents:
http://www.gnu.org/software/bash/manual/bashref.html#Here-Documents
> [n]<<[-]word
>         here-document
> delimiter
> No parameter and variable expansion, command substitution, arithmetic expansion, or filename expansion is performed on word. If any part of word is quoted, the delimiter is the result of quote removal on word, and the lines in the here-document are not expanded. If word is unquoted, all lines of the here-document are subjected to parameter expansion, command substitution, and arithmetic expansion, the character sequence \newline is ignored, and ‘\’ must be used to quote the characters ‘\’, ‘$’, and ‘`’.

Tested ssh_populate_same_account on our deployment and it fixed the issue we were seeing. The same changes were applied to ssh_populate_assume_role.