### PR TITLE
Deprecate "null_data_source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ It is considered normal to see very highly incremented counters if the load blan
 
 **It is essential to limit incoming service traffic to whitelisted ports.** If you do not then internet background noise will exhaust the host resources and/ or lead to rate limiting from amazon on the IAM identity calls- resulting in denial of service.
 
-The host is set to run the latest patch release at deployment of Debian Stretch - unless you specify a custom AMI. This Terraform has also been tested working with Ubuntu 18.04 'latest' host, e.g.:
+The host is set to run the latest patch release at deployment of Debian Stretch - unless you specify a custom AMI. This Terraform has also been tested working with Ubuntu 20.04 'latest' host, e.g.:
 
-## For Ubuntu 18.04 'latest' host
+## For Ubuntu 20.04 'latest' host
 
 ```bash
 data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
   filter {
     name   = "virtualization-type"
@@ -113,7 +113,7 @@ data "aws_ami" "ubuntu" {
 custom_ami_id = data.aws_ami.ubuntu.id
 ```
 
-Debian was chosen originally because the socket activation requires systemd but Ubuntu 16.04 did not automatically set up DHCP for additional elastic network interfaces (see version 1 series). Both Debian 10.x 'Buster' and Ubuntu 20.04 'Focal' have breaking changes around repository/package naming and Golang behaviour - look for support for these in a future release - contributions very welcome!
+Debian was chosen originally because the socket activation requires systemd but Ubuntu 16.04 did not automatically set up DHCP for additional elastic network interfaces (see version 1 series). Debian 10.x 'Buster' has breaking changes around repository/package naming and Golang behaviour - look for support for this in a future release - contributions very welcome!
 
 The host sshd is available on port 2222 and uses standard ec2 ssh keying. **The default login username for Debian AMI's is 'admin'**. If you do not whitelist any access to this port directly from the outside world (plan default) then it may be convenient to access from a container during development, e.g. with
 

--- a/examples/full-with-public-ip/main.tf
+++ b/examples/full-with-public-ip/main.tf
@@ -75,4 +75,7 @@ module "ssh-bastion-service" {
     aws_subnet.bastion,
     aws_internet_gateway.bastion,
   ]
+  tags = {
+    Demo = "true"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -48,17 +48,6 @@ resource "aws_launch_configuration" "bastion-service-host" {
 #######################################################
 # ASG section
 #######################################################
-
-data "null_data_source" "asg-tags" {
-  count = length(keys(var.tags))
-
-  inputs = {
-    key                 = element(keys(var.tags), count.index)
-    value               = element(values(var.tags), count.index)
-    propagate_at_launch = true
-  }
-}
-
 resource "aws_autoscaling_group" "bastion-service" {
   name_prefix          = "${var.service_name}-asg"
   max_size             = var.asg_max
@@ -71,11 +60,17 @@ resource "aws_autoscaling_group" "bastion-service" {
     aws_lb_target_group.bastion-host.*.arn
   )
 
-
   lifecycle {
     create_before_destroy = true
   }
-  tags = data.null_data_source.asg-tags.*.outputs
+
+  tags = [
+    for tag_key, tag_value in var.tags : {
+      "key"                 = tag_key
+      "value"               = tag_value
+      "propagate_at_launch" = true
+    }
+  ]
 }
 
 ####################################################

--- a/user_data/iam-authorized-keys-command.tpl
+++ b/user_data/iam-authorized-keys-command.tpl
@@ -12,5 +12,5 @@ COMMAND_DIR=$GOPATH/src/iam-authorized-keys-command
 mkdir -p $COMMAND_DIR
 cd $COMMAND_DIR
 
-go get ./...
-go build -ldflags "-X main.iamGroup=${bastion_allowed_iam_group}" -o /opt/iam_helper/iam-authorized-keys-command ./main.go
+sudo go get ./...
+sudo go build -ldflags "-X main.iamGroup=${bastion_allowed_iam_group}" -o /opt/iam_helper/iam-authorized-keys-command ./main.go


### PR DESCRIPTION
I have a feeling this implies at least terraform 13. I've been testing/developing w/ 0.14.8 thru 0.15.1.