### PR TITLE
Remove null_data_source as it was dropped in tf 0.15

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,16 +49,6 @@ resource "aws_launch_configuration" "bastion-service-host" {
 # ASG section
 #######################################################
 
-data "null_data_source" "asg-tags" {
-  count = length(keys(var.tags))
-
-  inputs = {
-    key                 = element(keys(var.tags), count.index)
-    value               = element(values(var.tags), count.index)
-    propagate_at_launch = true
-  }
-}
-
 resource "aws_autoscaling_group" "bastion-service" {
   name_prefix          = "${var.service_name}-asg"
   max_size             = var.asg_max
@@ -75,7 +65,14 @@ resource "aws_autoscaling_group" "bastion-service" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = data.null_data_source.asg-tags.*.outputs
+  dynamic "tags" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
 }
 
 ####################################################

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,8 @@ resource "aws_autoscaling_group" "bastion-service" {
   lifecycle {
     create_before_destroy = true
   }
-  dynamic "tags" {
+
+  dynamic "tag" {
     for_each = var.tags
     content {
       key                 = tag.key


### PR DESCRIPTION
This PR removes the null_data_source for asg-tags and replaces it with a dynamic block.
I think dynamic blocks were introduced at tf0.12 so there should not be any breaking changes