### PR TITLE
Feature/version 08

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfstate
+terraform.tfstate.backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 terraform.tfstate
 terraform.tfstate.backup
+.gitignore

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# 8.0
+
+- **Change:** Defaults to Debian 11 (host) and Ubuntu 22.04 (Container). Alternative combinations, distributions and non-AMD64 platforms not tested at this time. Tested using 
+  - Terraform v1.1.9
+  - hashicorp/aws v4.12.1
+  - hashicorp/cloudinit v2.2.0
+- **Change:** Hostname for container no longer increments. Sadly it wasn't possible to keep this working and the Docker team don't seem to like this practice - see (old 2015) https://stackoverflow.com/questions/43659410/docker-container-hostname-sequential-number 
+- **Change:** Moved to go mod to build golang binary (uses go1.15.15 linux/amd64 on Debian host)
+- **Change:** Default ebs device name changed: "xvda" => "/dev/sda1"
+- **Change:** example changes from t2.micro (which does not deploy successfully) to t3.micro
 # 7.0
 
 **Breaking changes with existing deployments using earlier module versions**

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - **Change:** Moved to go mod to build golang binary (uses go1.15.15 linux/amd64 on Debian host)
 - **Change:** Default ebs device name changed: "xvda" => "/dev/sda1"
 - **Change:** example changes from t2.micro (which does not deploy successfully) to t3.micro
+
 # 7.0
 
 **Breaking changes with existing deployments using earlier module versions**

--- a/examples/full-with-public-ip/README.md
+++ b/examples/full-with-public-ip/README.md
@@ -14,7 +14,7 @@ This example shows a complete setup for a new `bastion` service with all needed 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.12.1 |
 
 ## Modules
 
@@ -41,7 +41,7 @@ This example shows a complete setup for a new `bastion` service with all needed 
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Default AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cidr-start"></a> [cidr-start](#input\_cidr-start) | Default CIDR block | `string` | `"10.50"` | no |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | n/a | `string` | `"demo"` | no |
-| <a name="input_everyone-cidr"></a> [everyone-cidr](#input\_everyone-cidr) | Everyone | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_everyone_cidr"></a> [everyone\_cidr](#input\_everyone\_cidr) | Everyone | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | tags aplied to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/full-with-public-ip/README.md
+++ b/examples/full-with-public-ip/README.md
@@ -14,7 +14,7 @@ This example shows a complete setup for a new `bastion` service with all needed 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.12.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/examples/full-with-public-ip/main.tf
+++ b/examples/full-with-public-ip/main.tf
@@ -54,7 +54,7 @@ module "ssh-bastion-service" {
   vpc                           = aws_vpc.bastion.id
   subnets_asg                   = flatten([aws_subnet.bastion.*.id])
   subnets_lb                    = flatten([aws_subnet.bastion.*.id])
-  cidr_blocks_whitelist_service = [everyone_cidr]
+  cidr_blocks_whitelist_service = [var.everyone_cidr]
   public_ip                     = true
   depends_on = [
     aws_vpc.bastion,

--- a/examples/full-with-public-ip/main.tf
+++ b/examples/full-with-public-ip/main.tf
@@ -55,11 +55,10 @@ module "ssh-bastion-service" {
   subnets_asg                   = flatten([aws_subnet.bastion.*.id])
   subnets_lb                    = flatten([aws_subnet.bastion.*.id])
   cidr_blocks_whitelist_service = [var.everyone-cidr]
-  public_ip                     = true
   depends_on = [
     aws_vpc.bastion,
     aws_subnet.bastion,
     aws_internet_gateway.bastion,
   ]
-  bastion_instance_types = ["t2.micro"]
+  bastion_instance_types = ["t3.micro"]
 }

--- a/examples/full-with-public-ip/main.tf
+++ b/examples/full-with-public-ip/main.tf
@@ -41,7 +41,7 @@ resource "aws_route_table_association" "bastion" {
   route_table_id = aws_route_table.bastion.id
 }
 
-variable "everyone-cidr" {
+variable "everyone_cidr" {
   default     = "0.0.0.0/0"
   description = "Everyone"
 }
@@ -54,7 +54,8 @@ module "ssh-bastion-service" {
   vpc                           = aws_vpc.bastion.id
   subnets_asg                   = flatten([aws_subnet.bastion.*.id])
   subnets_lb                    = flatten([aws_subnet.bastion.*.id])
-  cidr_blocks_whitelist_service = [var.everyone-cidr]
+  cidr_blocks_whitelist_service = [everyone_cidr]
+  public_ip                     = true
   depends_on = [
     aws_vpc.bastion,
     aws_subnet.bastion,

--- a/examples/full-with-public-ip/versions.tf
+++ b/examples/full-with-public-ip/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -8,15 +8,16 @@ data "aws_region" "current" {
 
 data "aws_ami" "debian" {
   most_recent = true
-
   filter {
     name   = "name"
-    values = ["debian-stretch-hvm-x86_64-*"]
+    values = ["debian-11-amd64-*"]
   }
-
-  owners = ["379101102735"] # Debian
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["136693071363"] # Debian
 }
-
 
 ############################
 #Launch template for service host

--- a/user_data/docker_setup.tftpl
+++ b/user_data/docker_setup.tftpl
@@ -1,10 +1,7 @@
 #!/bin/bash
 #debian specific set up for docker https://docs.docker.com/install/linux/docker-ce/debian/#install-using-the-repository
-DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
-curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
-apt update
-DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce 
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gpg software-properties-common docker.io 
 systemctl start docker
 mkdir -p /opt/sshd_worker
 #Write out Dockerfile

--- a/user_data/iam-authorized-keys-command.tftpl
+++ b/user_data/iam-authorized-keys-command.tftpl
@@ -5,12 +5,14 @@ cat << EOF > /opt/golang/src/iam-authorized-keys-command/main.go
 EOF
 DEBIAN_FRONTEND=noninteractive
 sudo apt-get install -y golang
-export GOPATH=/opt/golang
 
-COMMAND_DIR=$GOPATH/src/iam-authorized-keys-command
+export GOPATH="/root/go"
+export GOCACHE="/root/.cache/go-build"
+export GOENV="/root/.config/go/env"
 
-mkdir -p $COMMAND_DIR
-cd $COMMAND_DIR
+cd /opt/golang/src/iam-authorized-keys-command
 
-go get ./...
-go build -ldflags "-X main.iamGroup=${bastion_allowed_iam_group}" -o /opt/iam_helper/iam-authorized-keys-command ./main.go
+go mod init iam-authorized-keys-command
+go mod tidy
+
+/usr/bin/go build -ldflags "-X main.iamGroup=${bastion_allowed_iam_group}" -o /opt/iam_helper/iam-authorized-keys-command ./main.go

--- a/user_data/systemd.tftpl
+++ b/user_data/systemd.tftpl
@@ -16,7 +16,7 @@ Description=SSH Per-Connection docker ssh container
 
 [Service]
 Type=simple
-ExecStart= /usr/bin/docker run --rm -i --hostname ${bastion_host_name}_%i -v /dev/log:/dev/log -v /opt/iam_helper:/opt:ro sshd_worker
+ExecStart= /usr/bin/docker run -i --rm -v /dev/log:/dev/log -v /opt/iam_helper:/opt:ro sshd_worker
 StandardInput=socket
 RuntimeMaxSec=43200
 

--- a/user_data/systemd.tftpl
+++ b/user_data/systemd.tftpl
@@ -16,7 +16,7 @@ Description=SSH Per-Connection docker ssh container
 
 [Service]
 Type=simple
-ExecStart= /usr/bin/docker run -i --rm -v /dev/log:/dev/log -v /opt/iam_helper:/opt:ro sshd_worker
+ExecStart= /usr/bin/docker run -i --hostname ${bastion_host_name} --rm -v /dev/log:/dev/log -v /opt/iam_helper:/opt:ro sshd_worker
 StandardInput=socket
 RuntimeMaxSec=43200
 

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "bastion_vpc_name" {
 
 variable "container_ubuntu_version" {
   description = "ubuntu version to use for service container. Tested with 16.04; 18.04; 20.04"
-  default     = "20.04"
+  default     = "22.04"
 }
 
 variable "extra_user_data_content" {
@@ -220,7 +220,7 @@ variable "bastion_ebs_size" {
 
 variable "bastion_ebs_device_name" {
   description = "Name of bastion instance block device"
-  default     = "xvda"
+  default     = "/dev/sda1"
 }
 
 variable "autoscaling_group_enabled_metrics" {

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "bastion_vpc_name" {
 }
 
 variable "container_ubuntu_version" {
-  description = "ubuntu version to use for service container. Tested with 16.04; 18.04; 20.04"
+  description = "ubuntu version to use for service container"
   default     = "22.04"
 }
 


### PR DESCRIPTION
# 8.0

- **Change:** Defaults to Debian 11 (host) and Ubuntu 22.04 (Container). Alternative combinations, distributions and non-AMD64 platforms not tested at this time. Tested using 
  - Terraform v1.1.9
  - hashicorp/aws v4.12.1
  - hashicorp/cloudinit v2.2.0
- **Change:** Hostname for container no longer increments. Sadly it wasn't possible to keep this working and the Docker team don't seem to like this practice - see (old 2015) https://stackoverflow.com/questions/43659410/docker-container-hostname-sequential-number 
- **Change:** Moved to go mod to build golang binary (uses go1.15.15 linux/amd64 on Debian host)
- **Change:** Default ebs device name changed: "xvda" => "/dev/sda1"
- **Change:** example changes from t2.micro (which does not deploy successfully) to t3.micro