### PR TITLE
Feature/launch template metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This Terraform deploys a stateless containerised sshd bastion service on AWS with IAM based authentication:
 
-This module requires Terraform >/=1.2.0 Older versions were previously supported going back to Terraform 0.11.x with module version to ~> v4.0
+This module requires Terraform >/=1.3.0 Older versions were previously supported going back to Terraform 0.11.x with module version to ~> v4.0
 
 **N.B. If you are using a newer version of this module when you have an older version deployed, please review the changelog!**
 
@@ -268,7 +268,7 @@ These have been generated with [terraform-docs](https://github.com/segmentio/ter
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 
@@ -332,7 +332,7 @@ No modules.
 | <a name="input_bastion_ebs_size"></a> [bastion\_ebs\_size](#input\_bastion\_ebs\_size) | Size of EBS attached to the bastion instance | `number` | `8` | no |
 | <a name="input_bastion_host_name"></a> [bastion\_host\_name](#input\_bastion\_host\_name) | The hostname to give to the bastion instance | `string` | `""` | no |
 | <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | List of ec2 types for the bastion host, used by aws\_launch\_template (first from the list) and in aws\_autoscaling\_group | `list` | <pre>[<br>  "t3.small",<br>  "t3.medium",<br>  "t3.large"<br>]</pre> | no |
-| <a name="input_bastion_metadata_options"></a> [bastion\_metadata\_options](#input\_bastion\_metadata\_options) | Passthrough for aws\_launch\_template.metadata\_options. Keys http\_endpoint, http\_tokens, http\_put\_response\_hop\_limit, http\_protocol\_ipv6, and instance\_metadata\_tags are supported. | `map(any)` | `{}` | no |
+| <a name="input_bastion_metadata_options"></a> [bastion\_metadata\_options](#input\_bastion\_metadata\_options) | Passthrough for aws\_launch\_template.metadata\_options. | <pre>object({<br>    http_endpoint               = optional(string)<br>    http_tokens                 = optional(string)<br>    http_put_response_hop_limit = optional(number)<br>    http_protocol_ipv6          = optional(string)<br>    instance_metadata_tags      = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_bastion_service_host_key_name"></a> [bastion\_service\_host\_key\_name](#input\_bastion\_service\_host\_key\_name) | AWS ssh key *.pem to be used for ssh access to the bastion service host | `string` | `""` | no |
 | <a name="input_bastion_service_port"></a> [bastion\_service\_port](#input\_bastion\_service\_port) | Port for containerised ssh daemon | `number` | `22` | no |
 | <a name="input_bastion_vpc_name"></a> [bastion\_vpc\_name](#input\_bastion\_vpc\_name) | define the last part of the hostname, by default this is the vpc ID with magic default value of 'vpc\_id' but you can pass a custom string, or an empty value to omit this | `string` | `"vpc_id"` | no |

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ name = "${var.environment_name}-${data.aws_region.current.name}-${var.vpc}-basti
 
 These have been generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -331,6 +332,7 @@ No modules.
 | <a name="input_bastion_ebs_size"></a> [bastion\_ebs\_size](#input\_bastion\_ebs\_size) | Size of EBS attached to the bastion instance | `number` | `8` | no |
 | <a name="input_bastion_host_name"></a> [bastion\_host\_name](#input\_bastion\_host\_name) | The hostname to give to the bastion instance | `string` | `""` | no |
 | <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | List of ec2 types for the bastion host, used by aws\_launch\_template (first from the list) and in aws\_autoscaling\_group | `list` | <pre>[<br>  "t3.small",<br>  "t3.medium",<br>  "t3.large"<br>]</pre> | no |
+| <a name="input_bastion_metadata_options"></a> [bastion\_metadata\_options](#input\_bastion\_metadata\_options) | Passthrough for aws\_launch\_template.metadata\_options. Keys http\_endpoint, http\_tokens, http\_put\_response\_hop\_limit, http\_protocol\_ipv6, and instance\_metadata\_tags are supported. | `map(any)` | `{}` | no |
 | <a name="input_bastion_service_host_key_name"></a> [bastion\_service\_host\_key\_name](#input\_bastion\_service\_host\_key\_name) | AWS ssh key *.pem to be used for ssh access to the bastion service host | `string` | `""` | no |
 | <a name="input_bastion_service_port"></a> [bastion\_service\_port](#input\_bastion\_service\_port) | Port for containerised ssh daemon | `number` | `22` | no |
 | <a name="input_bastion_vpc_name"></a> [bastion\_vpc\_name](#input\_bastion\_vpc\_name) | define the last part of the hostname, by default this is the vpc ID with magic default value of 'vpc\_id' but you can pass a custom string, or an empty value to omit this | `string` | `"vpc_id"` | no |
@@ -378,3 +380,4 @@ No modules.
 | <a name="output_policy_example_for_parent_account_empty_if_not_used"></a> [policy\_example\_for\_parent\_account\_empty\_if\_not\_used](#output\_policy\_example\_for\_parent\_account\_empty\_if\_not\_used) | You must apply an IAM policy with trust relationship identical or compatible with this in your other AWS account for IAM lookups to function there with STS:AssumeRole and allow users to login |
 | <a name="output_service_dns_entry"></a> [service\_dns\_entry](#output\_service\_dns\_entry) | dns-registered url for service and host |
 | <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | aws load balancer target group arn |
+<!-- END_TF_DOCS -->

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# TBD
+
+- **Feature:** EC2 instances can be supplied metadata options through `var.bastion_metadata_options`
+- **Change:** Increment required terraform version to >= 1.3.0
+
 # 8.1
 
 - **Feature:** Make default permissive outbound security group rule creation conditional: `var.custom_outbound_security_group` `type = bool`. Historic behaviour is followed by default

--- a/examples/custom-outbound-security-group/README.md
+++ b/examples/custom-outbound-security-group/README.md
@@ -30,7 +30,7 @@ ssh -p 443 user@load_balancer_dns_output_value
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 

--- a/examples/custom-outbound-security-group/versions.tf
+++ b/examples/custom-outbound-security-group/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/examples/full-with-public-ip/README.md
+++ b/examples/full-with-public-ip/README.md
@@ -8,7 +8,7 @@ This example shows a complete setup for a new `bastion` service with all needed 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 

--- a/examples/full-with-public-ip/versions.tf
+++ b/examples/full-with-public-ip/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -59,16 +59,12 @@ resource "aws_launch_template" "bastion-service-host" {
     }
   }
 
-  dynamic "metadata_options" {
-    for_each = length(keys(var.bastion_metadata_options)) > 0 ? { bastion_metadata_options = var.bastion_metadata_options } : {}
-
-    content {
-      http_endpoint               = lookup(metadata_options.value, "http_endpoint", "enabled")
-      http_tokens                 = lookup(metadata_options.value, "http_tokens", "optional")
-      http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", 1)
-      http_protocol_ipv6          = lookup(metadata_options.value, "http_protocol_ipv6", null)
-      instance_metadata_tags      = lookup(metadata_options.value, "instance_metadata_tags", null)
-    }
+  metadata_options {
+    http_endpoint               = try(var.bastion_metadata_options.http_endpoint, null)
+    http_tokens                 = try(var.bastion_metadata_options.http_tokens, null)
+    http_put_response_hop_limit = try(var.bastion_metadata_options.http_put_response_hop_limit, null)
+    http_protocol_ipv6          = try(var.bastion_metadata_options.http_protocol_ipv6, null)
+    instance_metadata_tags      = try(var.bastion_metadata_options.instance_metadata_tags, null)
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -59,12 +59,17 @@ resource "aws_launch_template" "bastion-service-host" {
     }
   }
 
-  metadata_options {
-    http_endpoint               = try(var.bastion_metadata_options.http_endpoint, null)
-    http_tokens                 = try(var.bastion_metadata_options.http_tokens, null)
-    http_put_response_hop_limit = try(var.bastion_metadata_options.http_put_response_hop_limit, null)
-    http_protocol_ipv6          = try(var.bastion_metadata_options.http_protocol_ipv6, null)
-    instance_metadata_tags      = try(var.bastion_metadata_options.instance_metadata_tags, null)
+  # Hide the `metadata_options` block if it's empty
+  dynamic "metadata_options" {
+    for_each = length(compact(values(var.bastion_metadata_options))) > 0 ? { bastion_metadata_options = var.bastion_metadata_options } : {}
+
+    content {
+      http_endpoint               = try(var.bastion_metadata_options.http_endpoint, null)
+      http_tokens                 = try(var.bastion_metadata_options.http_tokens, null)
+      http_put_response_hop_limit = try(var.bastion_metadata_options.http_put_response_hop_limit, null)
+      http_protocol_ipv6          = try(var.bastion_metadata_options.http_protocol_ipv6, null)
+      instance_metadata_tags      = try(var.bastion_metadata_options.instance_metadata_tags, null)
+    }
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,18 @@ resource "aws_launch_template" "bastion-service-host" {
     }
   }
 
+  dynamic "metadata_options" {
+    for_each = length(keys(var.bastion_metadata_options)) > 0 ? { bastion_metadata_options = var.bastion_metadata_options } : {}
+
+    content {
+      http_endpoint               = lookup(metadata_options.value, "http_endpoint", "enabled")
+      http_tokens                 = lookup(metadata_options.value, "http_tokens", "optional")
+      http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", 1)
+      http_protocol_ipv6          = lookup(metadata_options.value, "http_protocol_ipv6", null)
+      instance_metadata_tags      = lookup(metadata_options.value, "instance_metadata_tags", null)
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -238,3 +238,9 @@ variable "bastion_service_port" {
   description = "Port for containerised ssh daemon"
   default     = 22
 }
+
+variable "bastion_metadata_options" {
+  type        = map(any)
+  description = "Passthrough for aws_launch_template.metadata_options. Keys http_endpoint, http_tokens, http_put_response_hop_limit, http_protocol_ipv6, and instance_metadata_tags are supported."
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -240,7 +240,13 @@ variable "bastion_service_port" {
 }
 
 variable "bastion_metadata_options" {
-  type        = map(any)
-  description = "Passthrough for aws_launch_template.metadata_options. Keys http_endpoint, http_tokens, http_put_response_hop_limit, http_protocol_ipv6, and instance_metadata_tags are supported."
+  type = object({
+    http_endpoint               = optional(string)
+    http_tokens                 = optional(string)
+    http_put_response_hop_limit = optional(number)
+    http_protocol_ipv6          = optional(string)
+    instance_metadata_tags      = optional(string)
+  })
+  description = "Passthrough for aws_launch_template.metadata_options."
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
Hello! I would like to add the ability to specify metadata options for the instances that are created through this module.

Backwards-compatibility considerations:
- `var.bastion_metadata_options` is optional and defaults to no keys.
- The `metadata_options` block on the `aws_launch_template` resource will only be added if one or more `var.bastion_metadata_options` keys are provided.
- Defaults for `http_endpoint`, `http_tokens`, and `http_put_response_hop_limit` match the current version of the AWS provider ([v5.66.0](https://registry.terraform.io/providers/hashicorp/aws/5.66.0/docs/resources/launch_template#metadata-options)).
- Support for the last of the five specified `metadata_options` keys was added in provider version v3.72.0, which is older than the version mentioned in the README.

This was tested using Terraform version 1.9.4. I validated against 1.2.0 but have not deployed with the older version.